### PR TITLE
fix(compatibility healing event without being authorized)

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -8,6 +8,8 @@ local function syncStatus(statuses)
             Cache.statuses[name] = status
         end
     end
+
+    TriggerEvent("zyke_status:OnStatusFetched")
 end
 
 -- Wonder why we do this? It's explained in the `SyncPlayerStatus` server function

--- a/compatibility/server.lua
+++ b/compatibility/server.lua
@@ -58,12 +58,6 @@ RegisterNetEvent("zyke_status:compatibility:SoftResetStatuses", function()
     SoftResetStatuses(source)
 end)
 
-AddEventHandler("txAdmin:events:healedPlayer", function(eventData)
-    if (GetInvokingResource() ~= "monitor" or type(eventData) ~= "table" or type(eventData.id) ~= "number") then return end
-
-    TriggerClientEvent("esx_basicneeds:healPlayer", eventData.id)
-end)
-
 ---@param plyId PlayerId
 ---@param name string
 ---@return table | number | nil

--- a/dev/server/main.lua
+++ b/dev/server/main.lua
@@ -31,6 +31,15 @@ end, "Reset Player Status", {
     {"Player Id", "Player Id, or empty to use yourself"}
 })
 
+-- Forcefully save the status of yourself
+-- Mainly used for my own development when restarting & I want to save some initial state to resume from for each script restart
+Z.registerCommand({"status_save"}, function(plyId, args)
+    if (not isAllowed(plyId)) then Z.notify(plyId, "noPermission") return end
+
+    SavePlayerToDatabase(plyId)
+    Z.notify(plyId, "statusSaved")
+end)
+
 -- QB eating testing
 -- RegisterCommand("hunger_test", function(source, args)
 --     -- local ply = Z.getPlayerData(source)

--- a/effect_manager/effects/blockJumping.lua
+++ b/effect_manager/effects/blockJumping.lua
@@ -7,12 +7,17 @@ local active = false
 local jumpButton = Z.keys.get("SPACE")
 
 RegisterQueueKey("blockJumping", {
-    ---@param val BlockJumpingValue | true
+    ---@param val BlockJumpingValue | boolean
     ---@return BlockJumpingValue
     normalize = function(val)
-        return {
-            value = val.value or true
-        }
+        local _type = type(val)
+
+        if (_type == "boolean") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value}
+            ---@diagnostic disable-next-line: missing-return @ table or boolean, always returns something
+        end
     end,
     compare = function()
         return 0

--- a/effect_manager/effects/blockJumping.lua
+++ b/effect_manager/effects/blockJumping.lua
@@ -1,9 +1,22 @@
 -- Blocks the jump key
 
+---@class BlockJumpingValue
+---@field value boolean
+
 local active = false
 local jumpButton = Z.keys.get("SPACE")
 
 RegisterQueueKey("blockJumping", {
+    ---@param val BlockJumpingValue | true
+    ---@return BlockJumpingValue
+    normalize = function(val)
+        return {
+            value = val.value or true
+        }
+    end,
+    compare = function()
+        return 0
+    end,
     onStart = function()
         active = true
 

--- a/effect_manager/effects/blockSprinting.lua
+++ b/effect_manager/effects/blockSprinting.lua
@@ -1,9 +1,22 @@
 -- Blocks the sprint key
 
+---@class BlockSprintingValue
+---@field value boolean
+
 local active = false
 local sprintButton = Z.keys.get("LEFTSHIFT")
 
 RegisterQueueKey("blockSprinting", {
+    ---@param val BlockSprintingValue | true
+    ---@return BlockSprintingValue
+    normalize = function(val)
+        return {
+            value = val.value or true
+        }
+    end,
+    compare = function()
+        return 0
+    end,
     onStart = function()
         active = true
 

--- a/effect_manager/effects/blockSprinting.lua
+++ b/effect_manager/effects/blockSprinting.lua
@@ -7,12 +7,17 @@ local active = false
 local sprintButton = Z.keys.get("LEFTSHIFT")
 
 RegisterQueueKey("blockSprinting", {
-    ---@param val BlockSprintingValue | true
+    ---@param val BlockSprintingValue | boolean
     ---@return BlockSprintingValue
     normalize = function(val)
-        return {
-            value = val.value or true
-        }
+        local _type = type(val)
+
+        if (_type == "boolean") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value}
+            ---@diagnostic disable-next-line: missing-return @ table or boolean, always returns something
+        end
     end,
     compare = function()
         return 0

--- a/effect_manager/effects/blurryVision.lua
+++ b/effect_manager/effects/blurryVision.lua
@@ -1,8 +1,28 @@
 -- Fades a blurry overlay every now and then
 
+---@class BlurryVisionValue
+---@field value boolean
+
 local active = false
 
 RegisterQueueKey("blurryVision", {
+    ---@param val BlurryVisionValue | true
+    ---@return BlurryVisionValue
+    normalize = function(val)
+        return {
+            value = val.value or true
+        }
+    end,
+    ---@param thresholdIdx1 integer
+    ---@param thresholdIdx2 integer
+    ---@return integer
+    compare = function(_, _, thresholdIdx1, thresholdIdx2)
+        -- Could support intensity metadata in future
+        -- For now, use threshold
+        if (thresholdIdx1 > thresholdIdx2) then return -1
+        elseif (thresholdIdx1 < thresholdIdx2) then return 1
+        else return 0 end
+    end,
     onStart = function()
         active = true
 

--- a/effect_manager/effects/blurryVision.lua
+++ b/effect_manager/effects/blurryVision.lua
@@ -6,12 +6,17 @@
 local active = false
 
 RegisterQueueKey("blurryVision", {
-    ---@param val BlurryVisionValue | true
+    ---@param val BlurryVisionValue | boolean
     ---@return BlurryVisionValue
     normalize = function(val)
-        return {
-            value = val.value or true
-        }
+        local _type = type(val)
+
+        if (_type == "boolean") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value}
+            ---@diagnostic disable-next-line: missing-return @ table or boolean, always returns something
+        end
     end,
     ---@param thresholdIdx1 integer
     ---@param thresholdIdx2 integer

--- a/effect_manager/effects/cameraShaking.lua
+++ b/effect_manager/effects/cameraShaking.lua
@@ -15,10 +15,18 @@ RegisterQueueKey("cameraShaking", {
     ---@param val CameraShakingValue | string
     ---@return CameraShakingValue
     normalize = function(val)
-        return {
-            value = val.value or "DRUNK_SHAKE",
-            intensity = val.intensity or 1.0
-        }
+        local _type = type(val)
+        local defaultShakeType = "DRUNK_SHAKE"
+
+        if (_type == "string") then
+            return {value = val or defaultShakeType, intensity = 1.0}
+        elseif (_type == "table") then
+            return {
+                value = val.value or defaultShakeType,
+                intensity = val.intensity or 1.0
+            }
+            ---@diagnostic disable-next-line: missing-return @ table or string, always returns something
+        end
     end,
     ---@param val1 CameraShakingValue
     ---@param val2 CameraShakingValue

--- a/effect_manager/effects/cameraShaking.lua
+++ b/effect_manager/effects/cameraShaking.lua
@@ -4,16 +4,64 @@
 -- Possible issues
 -- If someone else is using the shaking, it may be overriden, perhaps check and make sure it is still played, possible suspects are recoil systems
 
-local baseShake = 1.0
+---@class CameraShakingValue
+---@field value string
+---@field intensity number
+
+local currShakeType = nil
+local currShakeIntensity = nil
 
 RegisterQueueKey("cameraShaking", {
-    onStart = function()
-        ShakeGameplayCam("DRUNK_SHAKE", baseShake)
+    ---@param val CameraShakingValue | string
+    ---@return CameraShakingValue
+    normalize = function(val)
+        return {
+            value = val.value or "DRUNK_SHAKE",
+            intensity = val.intensity or 1.0
+        }
+    end,
+    ---@param val1 CameraShakingValue
+    ---@param val2 CameraShakingValue
+    ---@param thresholdIdx1 integer
+    ---@param thresholdIdx2 integer
+    ---@return integer
+    compare = function(val1, val2, thresholdIdx1, thresholdIdx2)
+        -- If same shake type, compare intensity
+        if (val1.value == val2.value) then
+            if (val1.intensity > val2.intensity) then return -1
+            elseif (val1.intensity < val2.intensity) then return 1
+            else return 0 end
+        end
+
+        -- Different shake types - use threshold
+        if (thresholdIdx1 > thresholdIdx2) then return -1
+        elseif (thresholdIdx1 < thresholdIdx2) then return 1
+        else return 0 end
+    end,
+    ---@param val CameraShakingValue
+    onStart = function(val)
+        currShakeType = val.value
+        currShakeIntensity = val.intensity
+
+        ShakeGameplayCam(currShakeType, currShakeIntensity)
+    end,
+    ---@param val CameraShakingValue
+    onTick = function(val)
+        -- Re-apply if intensity changed
+        if (currShakeType ~= val.value or currShakeIntensity ~= val.intensity) then
+            ShakeGameplayCam(val.value, val.intensity)
+            currShakeType = val.value
+            currShakeIntensity = val.intensity
+        end
     end,
     reset = function()
         StopGameplayCamShaking(false)
+        currShakeType = nil
+        currShakeIntensity = nil
     end,
     onResourceStop = function()
         StopGameplayCamShaking(false)
+        currShakeType = nil
+        currShakeIntensity = nil
     end
 })

--- a/effect_manager/effects/cameraShaking.lua
+++ b/effect_manager/effects/cameraShaking.lua
@@ -47,12 +47,14 @@ RegisterQueueKey("cameraShaking", {
     end,
     ---@param val CameraShakingValue
     onTick = function(val)
-        -- Re-apply if intensity changed
-        if (currShakeType ~= val.value or currShakeIntensity ~= val.intensity) then
+        if (currShakeType == val.value and currShakeIntensity ~= val.intensity) then
+            SetGameplayCamShakeAmplitude(val.intensity)
+        elseif (currShakeType ~= val.value) then
             ShakeGameplayCam(val.value, val.intensity)
-            currShakeType = val.value
-            currShakeIntensity = val.intensity
         end
+
+        currShakeType = val.value
+        currShakeIntensity = val.intensity
     end,
     reset = function()
         StopGameplayCamShaking(false)

--- a/effect_manager/effects/movementSpeed.lua
+++ b/effect_manager/effects/movementSpeed.lua
@@ -12,9 +12,14 @@ RegisterQueueKey("movementSpeed", {
     ---@param val MovementSpeedValue | number
     ---@return MovementSpeedValue
     normalize = function(val)
-        return {
-            value = val.value or 1.0
-        }
+        local _type = type(val)
+
+        if (_type == "number") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value or 1.0}
+            ---@diagnostic disable-next-line: missing-return @ table or number, always returns something
+        end
     end,
     ---@param val1 MovementSpeedValue
     ---@param val2 MovementSpeedValue

--- a/effect_manager/effects/movementSpeed.lua
+++ b/effect_manager/effects/movementSpeed.lua
@@ -5,10 +5,30 @@
 -- Please note that reducing the speed too much may look incredibly weird and act somewhat weird
 -- We recommend not going lower than 0.8, paired with some modified running perhaps
 
+---@class MovementSpeedValue
+---@field value number
+
 RegisterQueueKey("movementSpeed", {
+    ---@param val MovementSpeedValue | number
+    ---@return MovementSpeedValue
+    normalize = function(val)
+        return {
+            value = val.value or 1.0
+        }
+    end,
+    ---@param val1 MovementSpeedValue
+    ---@param val2 MovementSpeedValue
+    ---@return integer
+    compare = function(val1, val2)
+        -- Numeric comparison - HIGHEST speed wins (least restrictive)
+        if (val1.value > val2.value) then return -1
+        elseif (val1.value < val2.value) then return 1
+        else return 0 end
+    end,
+    ---@param val MovementSpeedValue
     onTick = function(val)
-        SetRunSprintMultiplierForPlayer(PlayerId(), val)
-        SetEntityMaxSpeed(PlayerPedId(), val * 7.06)
+        SetRunSprintMultiplierForPlayer(PlayerId(), val.value)
+        SetEntityMaxSpeed(PlayerPedId(), val.value * 7.06)
     end,
     onResourceStop = function()
         SetRunSprintMultiplierForPlayer(PlayerId(), 1.0)

--- a/effect_manager/effects/screenEffect.lua
+++ b/effect_manager/effects/screenEffect.lua
@@ -98,10 +98,14 @@ RegisterQueueKey("screenEffect", {
     ---@param val ScreenEffectValue | string
     ---@return ScreenEffectValue
     normalize = function(val)
-        return {
-            value = val.value,
-            intensity = val.intensity or 1.0
-        }
+        local _type = type(val)
+
+        if (_type == "string") then
+            return {value = val, intensity = 1.0}
+        elseif (_type == "table") then
+            return {value = val.value, intensity = val.intensity or 1.0}
+            ---@diagnostic disable-next-line: missing-return @ table or string, always returns something
+        end
     end,
     ---@param val1 ScreenEffectValue
     ---@param val2 ScreenEffectValue

--- a/effect_manager/effects/screenEffect.lua
+++ b/effect_manager/effects/screenEffect.lua
@@ -1,31 +1,127 @@
 -- We utilize timecyclemods since it offers the best variety of screen effects
 
+---@class ScreenEffectValue
+---@field value string
+---@field intensity number
+
 local currScreenEffect = nil
+local currIntensity = nil
+local transitionStartTime = nil
+local TRANSITION_DURATION = 2.0 -- Duration in seconds for the transition (SetTransitionTimecycleModifier uses half-seconds, so 4.0 = 2.0s)
+local fadingOut = false
 
 -- Ensures that the correct screen effect is being played
----@param name string
-local function ensureScreenEffect(name)
-    if (not name) then return end
+---@param screenEffect ScreenEffectValue
+local function ensureScreenEffect(screenEffect)
+    local name = screenEffect.value
+    local intensity = screenEffect.intensity
+    local currentTime = GetGameTimer() / 1000.0
 
-    if (currScreenEffect ~= name or GetTimecycleModifierIndex() == -1) then
+    -- Cancel fade-out if a new effect is requested
+    if (fadingOut) then
+        fadingOut = false
+        Z.debug("Cancelling fade-out, new effect requested.")
+    end
+
+    -- Check if we're still in the transition period
+    local inTransition = transitionStartTime ~= nil and (currentTime - transitionStartTime) < TRANSITION_DURATION
+
+    -- If we're in a transition
+    if (inTransition) then
+        -- Allow upgrading to higher intensity of the same effect during transition
+        -- This handles the case where multiple thresholds are triggered rapidly
+        if (name == currScreenEffect and intensity > currIntensity) then
+            Z.debug(("Upgrading timecycle (screen) effect %s from intensity %.2f to %.2f during transition."):format(name, currIntensity, intensity))
+            SetTimecycleModifierStrength(intensity)
+            currIntensity = intensity
+        end
+
+        -- Otherwise, block all changes during transition
+        return
+    end
+
+    -- Only check GetTimecycleModifierIndex() if we're not in a transition
+    -- It detects as -1 even if we're fading into a new effect
+    local modifierMissing = GetTimecycleModifierIndex() == -1
+
+    if (currScreenEffect ~= name or currIntensity ~= intensity or modifierMissing) then
         if (currScreenEffect ~= nil) then
             ClearTimecycleModifier()
         end
 
-        Z.debug(("Now playing timecycle (screen) effect %s."):format(name))
-        SetTimecycleModifier(name)
-        SetTransitionTimecycleModifier(name, 4.0)
+        Z.debug(("Now playing timecycle (screen) effect %s with intensity %.2f."):format(name, intensity))
+        SetTransitionTimecycleModifier(name, TRANSITION_DURATION)
+        SetTimecycleModifierStrength(intensity)
         currScreenEffect = name
+        currIntensity = intensity
+        transitionStartTime = currentTime
     end
 end
 
 local function clearScreenEffect()
+    if (currScreenEffect ~= nil) then
+        Z.debug("Clearing timcycle (screen) effect with transition.")
+
+        local startIntensity = currIntensity
+        local fadeStartTime = GetGameTimer() / 1000.0
+        fadingOut = true
+
+        -- Gradually fade out over the transition duration
+        CreateThread(function()
+            while fadingOut do
+                local currentTime = GetGameTimer() / 1000.0
+                local elapsed = currentTime - fadeStartTime
+
+                if elapsed >= TRANSITION_DURATION then
+                    -- Fade complete, clear the modifier
+                    ClearTimecycleModifier()
+                    fadingOut = false
+                    break
+                end
+
+                -- Calculate fade progress (1.0 to 0.0)
+                local progress = 1.0 - (elapsed / TRANSITION_DURATION)
+                local newIntensity = startIntensity * progress
+                SetTimecycleModifierStrength(newIntensity)
+
+                Wait(50) -- Update every 50ms for smooth fade
+            end
+        end)
+    end
+
     currScreenEffect = nil
-    ClearTimecycleModifier()
-    Z.debug("Clearing timcycle (screen) effect.")
+    currIntensity = nil
+    transitionStartTime = nil
 end
 
 RegisterQueueKey("screenEffect", {
+    ---@param val ScreenEffectValue | string
+    ---@return ScreenEffectValue
+    normalize = function(val)
+        return {
+            value = val.value,
+            intensity = val.intensity or 1.0
+        }
+    end,
+    ---@param val1 ScreenEffectValue
+    ---@param val2 ScreenEffectValue
+    ---@param thresholdIdx1 integer
+    ---@param thresholdIdx2 integer
+    ---@return integer
+    compare = function(val1, val2, thresholdIdx1, thresholdIdx2)
+        -- If same effect name, compare intensity (higher intensity wins)
+        if (val1.value == val2.value) then
+            if (val1.intensity > val2.intensity) then return -1
+            elseif (val1.intensity < val2.intensity) then return 1
+            else return 0 end
+        end
+
+        -- Different effects - use threshold (higher threshold = more severe)
+        if (thresholdIdx1 > thresholdIdx2) then return -1
+        elseif (thresholdIdx1 < thresholdIdx2) then return 1
+        else return 0 end
+    end,
+    ---@param val ScreenEffectValue
     onTick = function(val)
         ensureScreenEffect(val)
     end,

--- a/effect_manager/effects/strength.lua
+++ b/effect_manager/effects/strength.lua
@@ -1,10 +1,28 @@
+---@class StrengthValue
+---@field value number
+
 local handHash = `WEAPON_UNARMED`
 
 RegisterQueueKey("strength", {
+    ---@param val StrengthValue | number
+    ---@return StrengthValue
+    normalize = function(val)
+        return {
+            value = val.value or 1.0
+        }
+    end,
+    ---@param val1 StrengthValue
+    ---@param val2 StrengthValue
+    ---@return integer
+    compare = function(val1, val2)
+        -- Numeric comparison - HIGHEST strength wins
+        if (val1.value > val2.value) then return -1
+        elseif (val1.value < val2.value) then return 1
+        else return 0 end
+    end,
+    ---@param val StrengthValue
     onTick = function(val)
-		if (type(val) ~= "number") then return end
-
-		SetWeaponDamageModifier(handHash, val)
+		SetWeaponDamageModifier(handHash, val.value)
     end,
 	reset = function()
 		SetWeaponDamageModifier(handHash, 1.0)

--- a/effect_manager/effects/strength.lua
+++ b/effect_manager/effects/strength.lua
@@ -7,9 +7,14 @@ RegisterQueueKey("strength", {
     ---@param val StrengthValue | number
     ---@return StrengthValue
     normalize = function(val)
-        return {
-            value = val.value or 1.0
-        }
+        local _type = type(val)
+
+        if (_type == "number") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value or 1.0}
+            ---@diagnostic disable-next-line: missing-return @ table or number, always returns something
+        end
     end,
     ---@param val1 StrengthValue
     ---@param val2 StrengthValue

--- a/effect_manager/effects/stumble.lua
+++ b/effect_manager/effects/stumble.lua
@@ -2,6 +2,9 @@
 -- When walking it's very rare, but when running it will frequently happen
 -- The effect value will multiply the chance at the very end, so 2.0 value will double your chance of stumbling
 
+---@class StumbleValue
+---@field value number
+
 local baseChance = 1 -- 1% chance to stumble, every second, should be low if we're just standing still
 local walkingAddition = 3 -- 3% EXTRA chance to stumble, added on top of baseChance
 local runningAddition = 10 -- 10% EXTRA chance to stumble, added on top of baseChance, walkingAddition is not added if runningAddition is being added
@@ -10,9 +13,25 @@ local runningAddition = 10 -- 10% EXTRA chance to stumble, added on top of baseC
 local value = 0.0
 
 RegisterQueueKey("stumble", {
+    ---@param val StumbleValue | number
+    ---@return StumbleValue
+    normalize = function(val)
+        return {
+            value = val.value or 0.0
+        }
+    end,
+    ---@param val1 StumbleValue
+    ---@param val2 StumbleValue
+    ---@return integer
+    compare = function(val1, val2)
+        -- Numeric comparison - HIGHEST stumble chance wins (most severe)
+        if (val1.value > val2.value) then return -1
+        elseif (val1.value < val2.value) then return 1
+        else return 0 end
+    end,
+	---@param val StumbleValue
     onStart = function(val)
-		if (type(val) ~= "number") then return end
-        value = val
+        value = val.value
 
         CreateThread(function()
             while (value ~= 0.0) do
@@ -40,10 +59,9 @@ RegisterQueueKey("stumble", {
             end
         end)
     end,
+	---@param val StumbleValue
 	onTick = function(val)
-		if (type(val) ~= "number") then return end
-
-		value = val
+		value = val.value
 	end,
 	onStop = function()
 		value = 0.0

--- a/effect_manager/effects/stumble.lua
+++ b/effect_manager/effects/stumble.lua
@@ -16,9 +16,14 @@ RegisterQueueKey("stumble", {
     ---@param val StumbleValue | number
     ---@return StumbleValue
     normalize = function(val)
-        return {
-            value = val.value or 0.0
-        }
+        local _type = type(val)
+
+        if (_type == "number") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value or 0.0}
+            ---@diagnostic disable-next-line: missing-return @ table or number, always returns something
+        end
     end,
     ---@param val1 StumbleValue
     ---@param val2 StumbleValue

--- a/effect_manager/effects/walkingStyle.lua
+++ b/effect_manager/effects/walkingStyle.lua
@@ -1,3 +1,6 @@
+---@class WalkingStyleValue
+---@field value string
+
 -- A list of movement styles we won't override
 -- For example, crouching counts as a movement style which we don't want to override
 -- Don't forget to hash it
@@ -36,8 +39,26 @@ local function clearWalkingStyle()
 end
 
 RegisterQueueKey("walkingStyle", {
+    ---@param val WalkingStyleValue | string
+    ---@return WalkingStyleValue
+    normalize = function(val)
+        return {
+            value = val.value
+        }
+    end,
+    ---@param thresholdIdx1 integer
+    ---@param thresholdIdx2 integer
+    ---@return integer
+    compare = function(_, _, thresholdIdx1, thresholdIdx2)
+        -- Different walking styles, use threshold
+        -- Higher threshold = more severe impairment
+        if (thresholdIdx1 > thresholdIdx2) then return -1
+        elseif (thresholdIdx1 < thresholdIdx2) then return 1
+        else return 0 end
+    end,
+    ---@param val WalkingStyleValue
     onTick = function(val)
-        ensureWalkingStyle(val)
+        ensureWalkingStyle(val.value)
     end,
     onResourceStop = function()
         clearWalkingStyle()

--- a/effect_manager/effects/walkingStyle.lua
+++ b/effect_manager/effects/walkingStyle.lua
@@ -42,9 +42,14 @@ RegisterQueueKey("walkingStyle", {
     ---@param val WalkingStyleValue | string
     ---@return WalkingStyleValue
     normalize = function(val)
-        return {
-            value = val.value
-        }
+        local _type = type(val)
+
+        if (_type == "string") then
+            return {value = val}
+        elseif (_type == "table") then
+            return {value = val.value}
+            ---@diagnostic disable-next-line: missing-return @ table or string, always returns something
+        end
     end,
     ---@param thresholdIdx1 integer
     ---@param thresholdIdx2 integer

--- a/effect_manager/main.lua
+++ b/effect_manager/main.lua
@@ -17,7 +17,7 @@ function RegisterEffectFunctions(name)
     local queueIdPrefix = name
 
     local function getQueueId(thresholdIdx)
-        return queueIdPrefix .. ":" .. thresholdIdx
+        return queueIdPrefix .. ";" .. thresholdIdx
     end
 
     EffectFunctions[name] = {

--- a/effect_manager/main.lua
+++ b/effect_manager/main.lua
@@ -14,6 +14,12 @@ function RegisterEffectFunctions(name)
     local statusSettings = GetStatusSettings(primary, secondary)
     if (not statusSettings) then return end
 
+    local queueIdPrefix = name
+
+    local function getQueueId(thresholdIdx)
+        return queueIdPrefix .. ":" .. thresholdIdx
+    end
+
     EffectFunctions[name] = {
         onStart = function(val, thresholdIdx, _, highestThresholdIdx)
             -- print("onStart", name, thresholdIdx, highestThresholdIdx)
@@ -23,7 +29,7 @@ function RegisterEffectFunctions(name)
             local keys = GetExistingQueueKeys()
             for i = 1, #keys do
                 if (statusSettings.effect[thresholdIdx][keys[i]]) then
-                    AddToQueue(keys[i], name, thresholdIdx)
+                    AddToQueue(keys[i], getQueueId(thresholdIdx), thresholdIdx)
                 end
             end
 
@@ -66,7 +72,7 @@ function RegisterEffectFunctions(name)
                 local value = statusSettings.effect[thresholdIdx][keys[i]]
 
                 if (value) then
-                    RemoveFromQueue(keys[i], name, value)
+                    RemoveFromQueue(keys[i], getQueueId(thresholdIdx), value)
                 end
             end
         end

--- a/effect_manager/main.lua
+++ b/effect_manager/main.lua
@@ -59,11 +59,14 @@ function RegisterEffectFunctions(name)
                 AddToStat("health", -amount)
             end
         end,
-        onStop = function(val, thresholdIdx)
+        onStop = function(_, thresholdIdx)
             local keys = GetExistingQueueKeys()
+
             for i = 1, #keys do
-                if (statusSettings.effect[thresholdIdx][keys[i]]) then
-                    RemoveFromQueue(keys[i], name, statusSettings.effect[thresholdIdx][keys[i]])
+                local value = statusSettings.effect[thresholdIdx][keys[i]]
+
+                if (value) then
+                    RemoveFromQueue(keys[i], name, value)
                 end
             end
         end

--- a/effect_manager/queue.lua
+++ b/effect_manager/queue.lua
@@ -126,6 +126,11 @@ function AddToQueue(queueKey, queueId, thresholdIdx, value, newThresholdToActiva
         }, {indent = true}))
     end
 
+    if (queues[queueKey] and queues[queueKey][queueId]) then
+        error(("Queue already exists for queueKey: '%s' and queueId: '%s'"):format(queueKey, queueId))
+        return false
+    end
+
     -- This threshold part is a little messy and will probably be refactored in the future, but the concept is working
 
     -- Keep the previous threshold

--- a/effect_manager/queue.lua
+++ b/effect_manager/queue.lua
@@ -54,10 +54,10 @@ local prevEffects = {}
 ---@field compare CompareFunction Comparison function to determine dominant value
 ---@field normalize NormalizeFunction Normalization/validation function to add defaults and validate
 ---@field onResourceStop fun()?
----@field onTick fun(value: RichEffectValue, queueId: string)?
+---@field onTick fun(value: RichEffectValue, queueId: string, effectMultiplier: number)?
 ---@field reset fun()?
----@field onStart fun(value: RichEffectValue, queueId: string)?
----@field onStop fun(value: RichEffectValue, queueId: string)?
+---@field onStart fun(value: RichEffectValue, queueId: string, effectMultiplier: number)?
+---@field onStop fun(value: RichEffectValue, queueId: string, effectMultiplier: number)?
 
 ---@type table<QueueKey, EffectFunctions>
 local funcs = {}
@@ -316,7 +316,8 @@ RegisterNetEvent("zyke_status:OnQueueUpdated", function()
 
     queueActive = true
     while (queueActive) do
-        local sleep = 1000
+        local sleep = 250
+        local effectMultiplier = sleep / 1000
 
         ---@type table<QueueKey, {queueId: string, value: RichEffectValue}>
         newEffects = {}
@@ -345,12 +346,12 @@ RegisterNetEvent("zyke_status:OnQueueUpdated", function()
                     prevEffects[queueKey] == nil
                 ) then
                     if (funcs[queueKey].onStart) then
-                        funcs[queueKey].onStart(queueData[dominantQueueId].value, dominantQueueId)
+                        funcs[queueKey].onStart(queueData[dominantQueueId].value, dominantQueueId, effectMultiplier)
                     end
                 end
 
                 if (funcs[queueKey].onTick) then
-                    funcs[queueKey].onTick(queueData[dominantQueueId].value, dominantQueueId)
+                    funcs[queueKey].onTick(queueData[dominantQueueId].value, dominantQueueId, effectMultiplier)
                 end
 
                 newEffects[queueKey] = {queueId = dominantQueueId, value = queueData[dominantQueueId].value}
@@ -366,7 +367,7 @@ RegisterNetEvent("zyke_status:OnQueueUpdated", function()
 
             if (not richValuesEqual(prevEffects[queueKey], newEffects[queueKey])) then
                 if (funcs[queueKey].onStop) then
-                    funcs[queueKey].onStop(prevQueueData.value, prevQueueData.queueId)
+                    funcs[queueKey].onStop(prevQueueData.value, prevQueueData.queueId, effectMultiplier)
                 end
             end
         end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -12,4 +12,5 @@ return {
     -- Dev command stuff
     ["invalidAmount"] = {msg = "Invalid amount.", type = "error"},
     ["incorrectAction"] = {msg = "Incorrect action input", type = "error"},
+    ["statusSaved"] = {msg = "Status has been saved to database.", type = "success"},
 }

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -9,6 +9,12 @@ return {
     ["playerStatusUnfrozen"] = {msg = "Player's status has been unfrozen.", type = "success"},
     ["noServerFreeze"] = {msg = "You can not freeze the server.", type = "error"},
 
+    ["stress1"] = {msg = "You are feeling a bit stressed.", type = "info"},
+    ["stress2"] = {msg = "You are feeling quite stressed.", type = "error"},
+    ["stress3"] = {msg = "You are feeling very stressed.", type = "error"},
+    ["stress4"] = {msg = "You are feeling extremely stressed.", type = "error"},
+    ["stress5"] = {msg = "You are feeling critically stressed.", type = "error"},
+
     -- Dev command stuff
     ["invalidAmount"] = {msg = "Invalid amount.", type = "error"},
     ["incorrectAction"] = {msg = "Incorrect action input", type = "error"},

--- a/server/freeze_status.lua
+++ b/server/freeze_status.lua
@@ -37,7 +37,7 @@ function UnfreezeStatus(plyId)
 	Z.debug("Unfroze status for", plyId)
 end
 
----@return FrozenPlayer[]
+---@return table<PlayerId, FrozenPlayer>
 function GetFrozenPlayers()
 	return frozenPlayers
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -353,8 +353,9 @@ function SoftResetStatuses(plyId)
             end
         end
     end
-
 end
+
+exports("SoftResetStatuses", SoftResetStatuses)
 
 local playerHealAuth = {}
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -335,6 +335,8 @@ function ResetStatuses(plyId)
     end
 end
 
+exports("ResetStatuses", ResetStatuses)
+
 -- Runs onSoftReset and falls back to onReset for all statuses the player has registered
 ---@param plyId PlayerId
 function SoftResetStatuses(plyId)

--- a/statuses/hunger/config.lua
+++ b/statuses/hunger/config.lua
@@ -5,9 +5,32 @@ Config.Status.hunger = {
             drain = 0.005,
         },
         effect = {
-            {threshold = 20.0, screenEffect = "WeaponUpgrade"}, -- A screen effect to simulate that you are being affected by hunger
-            {threshold = 10.0, walkingStyle = "move_m@sad@a", blockSprinting = true, blockJumping = true}, -- Walking more sluggish, block high-energy actions like sprinting and jumping
-            {threshold = 0.0, damage = 0.25}, -- Start taking some damage
+            {
+                -- Start being hungry, slight screen effect
+                threshold = 20.0,
+                screenEffect = {value = "WeaponUpgrade", intensity = 0.6},
+            },
+            {
+                -- Start being very hungry, noticeable screen effect
+                -- Very slight camera shaking
+                threshold = 10.0,
+                screenEffect = {value = "WeaponUpgrade", intensity = 0.7},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.2},
+                walkingStyle = "move_m@sad@a",
+            },
+            {
+                -- Complete starvation
+                -- Very noticeable screen effect, impaired vision
+                -- Taking slow damage
+                -- Noticeable camera shaking, feeling dizzy
+                -- Restricted movement due to low energy levels
+                threshold = 0.0,
+                screenEffect = {value = "WeaponUpgrade", intensity = 0.8},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.8},
+                blockSprinting = true,
+                blockJumping = true,
+                damage = 0.25
+            },
         }
     }
 }

--- a/statuses/stress/config.lua
+++ b/statuses/stress/config.lua
@@ -9,26 +9,33 @@ Config.Status.stress = {
                 threshold = 10.0,
                 screenEffect = {value = "BarryFadeOut", intensity = 0.1},
                 cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.05},
+                notification = {value = "stress1", play = "start"}
+                -- notification = {value = "stress1", play = "start", force = true} -- You can use force here to forcefully always play this notification even if you surpass multiple thresholds in one go
             },
             {
                 threshold = 20.0,
                 screenEffect = {value = "BarryFadeOut", intensity = 0.3},
                 cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.1},
+                notification = {value = "stress2", play = "start"}
             },
             {
                 threshold = 30.0,
                 screenEffect = {value = "BarryFadeOut", intensity = 0.5},
                 cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.2},
+                notification = {value = "stress3", play = "start"}
             },
             {
                 threshold = 50.0,
                 screenEffect = {value = "BarryFadeOut", intensity = 0.8},
                 cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.8},
+                notification = {value = "stress4", play = "start"}
             },
             {
                 threshold = 70.0,
                 screenEffect = {value = "BarryFadeOut", intensity = 1.5},
                 cameraShaking = {value = "DRUNK_SHAKE", intensity = 1.5},
+                notification = {value = "stress5", play = "start"}
+                -- notification = {value = "You are feeling critically stressed.", type = "warning", play = "start"} -- We also allow direct notification messages without any translations
             },
         }
     }

--- a/statuses/stress/config.lua
+++ b/statuses/stress/config.lua
@@ -1,11 +1,35 @@
 Config.Status.stress = {
     ["base"] = {
+        -- Gradually impair vision with a blurry & saturating screen effect with some camera shaking
+        -- The first few thresholds are manageable, you'll see that you are getting some effects but won't affect gameplay
+        -- When you reach roughly the mid-point of the maximum threshold, it'll really kick off and restrict you
+        -- You can adjust this as needed, current lows shows some imparment with highs really messing with you
         effect = {
             {
+                threshold = 10.0,
+                screenEffect = {value = "BarryFadeOut", intensity = 0.1},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.05},
+            },
+            {
+                threshold = 20.0,
+                screenEffect = {value = "BarryFadeOut", intensity = 0.3},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.1},
+            },
+            {
                 threshold = 30.0,
-                screenEffect = "BeastLaunch02",
-                blurryVision = true,
-            }
-        },
+                screenEffect = {value = "BarryFadeOut", intensity = 0.5},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.2},
+            },
+            {
+                threshold = 50.0,
+                screenEffect = {value = "BarryFadeOut", intensity = 0.8},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.8},
+            },
+            {
+                threshold = 70.0,
+                screenEffect = {value = "BarryFadeOut", intensity = 1.5},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 1.5},
+            },
+        }
     }
 }

--- a/statuses/thirst/config.lua
+++ b/statuses/thirst/config.lua
@@ -5,9 +5,32 @@ Config.Status.thirst = {
             drain = 0.01,
         },
         effect = {
-            {threshold = 20.0, screenEffect = "BeastLaunch02"},
-            {threshold = 10.0, blockSprinting = true, blockJumping = true, walkingStyle = "move_m@sad@a"},
-            {threshold = 0.0, damage = 0.25}
+            {
+                -- Minor shaking & screen effect
+                threshold = 20.0,
+                screenEffect = {value = "BeastLaunch02", intensity = 0.25},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.2}
+            },
+            {
+                -- Noticeable shaking & screen effect
+                -- Due to dehydration, block sprinting & jumping
+                -- Walking style is more sluggish
+                threshold = 10.0,
+                screenEffect = {value = "BeastLaunch02", intensity = 0.5},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.35},
+                blockSprinting = true,
+                blockJumping = true,
+                walkingStyle = "move_m@sad@a"
+            },
+            {
+                -- Complete dehydration
+                -- Very noticeable shaking & screen effect, impaired vision
+                -- Taking slow damage
+                threshold = 0.0,
+                screenEffect = {value = "BeastLaunch02", intensity = 1.0},
+                cameraShaking = {value = "DRUNK_SHAKE", intensity = 0.75},
+                damage = 0.25
+            },
         }
     }
 }


### PR DESCRIPTION
`txAdmin:events:healedPlayer` is already handled in `server/events.lua`

this duplicate handler was causing the "healing event without being authorized" warning

https://github.com/ZykeWasTaken/zyke_status/blob/b41c60adbb468d55c9bd92a6d933d867962beadb/server/events.lua#L27-L34